### PR TITLE
Updated for ES 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 2.4.0          | 2.4.0.0        | Sep 06, 2016 |
 | 2.3.5          | 2.3.5.0        | Aug 24, 2016 |
 | 2.3.4          | 2.3.4.0        | Jul 22, 2016 |
 | 2.3.3          | 2.3.3.0        | May 27, 2016 |
@@ -35,7 +36,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 The plugin artifacts are published to Maven Central. To install a prepackaged plugin for ES 2.x+ use the following command:
 
 ```
-bin/plugin install com.automattic/elasticsearch-statsd/2.3.5.0
+bin/plugin install com.automattic/elasticsearch-statsd/2.4.0.0
 ```
 
 Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
@@ -46,7 +47,7 @@ You can also build your own by doing the following:
 git clone http://github.com/Automattic/elasticsearch-statsd-plugin.git
 cd elasticsearch-statsd-plugin
 mvn package -Dtests.security.manager=false
-bin/plugin file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-2.3.5.0.zip
+bin/plugin file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-2.4.0.0.zip
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>2.3.5.0</version>
+    <version>2.4.0.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -42,8 +42,8 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>2.3.5</elasticsearch.version>
-        <lucene.version>5.5.0</lucene.version>
+        <elasticsearch.version>2.4.0</elasticsearch.version>
+        <lucene.version>5.5.2</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
         <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I followed the previous commits to bump versions for ES 2.4.0. Integration tests pass, and I'm able to `bin/plugin install` the resulting plugin zip.