### PR TITLE
Send open_contexts to StatsD

### DIFF
--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdReporterIndexStats.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdReporterIndexStats.java
@@ -50,6 +50,7 @@ public abstract class StatsdReporterIndexStats extends StatsdReporter {
 
     protected void sendSearchStats(String name, SearchStats searchStats) {
         if (null == searchStats) return;
+        this.sendGauge(name, "open_contexts", searchStats.getOpenContexts());
         SearchStats.Stats totalSearchStats = searchStats.getTotal();
         this.sendSearchStatsStats(name, totalSearchStats);
 


### PR DESCRIPTION
In ES `open_contexts` is a long representing the number of concurrent searches happening "right now" looks like it was added a while ago:

https://github.com/elastic/elasticsearch/commit/271305d5ebe74fbca3348f4c5f482c240d76457c

So it should be safe to send this metric in all versions of the plugin. Graphing this stat would be useful to know how loaded a cluster is with search requests as well as which indices are responsible.