### PR TITLE
Upgrade to Elasticsearch 6.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-script: mvn clean verify
+script: mvn clean verify -Djava.security.policy=src/test/resources/plugin-security-test.policy
 
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
-| 6.1.1          | 6.1.1.0        | Jan 02, 2018 |
+| 6.1.1          | 6.1.1.0        | Jan 08, 2018 |
 | 5.6.5          | 5.6.5.0        | Dec 19, 2017 |
 | 5.6.4          | 5.6.4.0        | Nov 13, 2017 |
 | 5.6.3          | 5.6.3.0        | Oct 12, 2017 |
@@ -93,9 +93,40 @@ Once we have the artifact, install it with the following command:
 bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.1.1.0.zip
 ```
 
-## Installation Elasticsearch 2.x-5.x
+## Installation Elasticsearch 5.x
 
-The plugin artifacts are published to Maven Central. To install a prepackaged plugin use the following command:
+The plugin artifacts are published to Maven Central and Github. To install a prepackaged plugin for ES 5.x+ use the following command:
+
+From Github:
+
+```
+./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/5.6.5.0/elasticsearch-statsd-5.6.5.0.zip
+```
+
+From Maven Central:
+```
+./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/5.6.5.0/elasticsearch-statsd-5.6.5.0.zip
+```
+
+Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
+
+You can also build your own by doing the following:
+
+```
+git clone http://github.com/Automattic/elasticsearch-statsd-plugin.git
+cd elasticsearch-statsd-plugin
+mvn package
+```
+
+Once we have the artifact, install it with the following command:
+
+```
+./bin/elasticsearch-plugin install file:///Users/anandnalya/github/automattic/elasticsearch-statsd-plugin/target/releases/elasticsearch-statsd-5.6.5.0.zip
+```
+
+## Installation Elasticsearch 2.x
+
+The plugin artifacts are published to Maven Central. To install a prepackaged plugin for ES 2.x use the following command:
 
 ```
 bin/plugin install com.automattic/elasticsearch-statsd/2.4.4.0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 6.1.1          | 6.1.1.0        | Jan 02, 2018 |
 | 5.6.5          | 5.6.5.0        | Dec 19, 2017 |
 | 5.6.4          | 5.6.4.0        | Nov 13, 2017 |
 | 5.6.3          | 5.6.3.0        | Oct 12, 2017 |
@@ -61,19 +62,19 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 | < 1.5.x        | 0.3.3          | Aug 20, 2014 |
 
 
-## Installation Elasticsearch 5.x
+## Installation Elasticsearch 6.x
 
-The plugin artifacts are published to Maven Central and Github. To install a prepackaged plugin for ES 5.x+ use the following command:
+The plugin artifacts are published to Maven Central and Github. To install a prepackaged plugin for ES 6.x+ use the following command:
 
 From Github:
 
 ```
-./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/5.6.5.0/elasticsearch-statsd-5.6.5.0.zip
+./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/6.1.1.0/elasticsearch-statsd-6.1.1.0.zip
 ```
 
 From Maven Central:
 ```
-./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/5.6.5.0/elasticsearch-statsd-5.6.5.0.zip
+./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.1.1.0/elasticsearch-statsd-6.1.1.0.zip
 ```
 
 Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
@@ -83,18 +84,18 @@ You can also build your own by doing the following:
 ```
 git clone http://github.com/Automattic/elasticsearch-statsd-plugin.git
 cd elasticsearch-statsd-plugin
-mvn package
+mvn package -Djava.security.policy=src/test/resources/plugin-security-test.policy
 ```
 
 Once we have the artifact, install it with the following command:
 
 ```
-./bin/elasticsearch-plugin install file:///Users/anandnalya/github/automattic/elasticsearch-statsd-plugin/target/releases/elasticsearch-statsd-5.6.5.0.zip
+bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.1.1.0.zip
 ```
 
-## Installation Elasticsearch 2.x
+## Installation Elasticsearch 2.x-5.x
 
-The plugin artifacts are published to Maven Central. To install a prepackaged plugin for ES 2.x use the following command:
+The plugin artifacts are published to Maven Central. To install a prepackaged plugin use the following command:
 
 ```
 bin/plugin install com.automattic/elasticsearch-statsd/2.4.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>5.6.5.0</version>
+    <version>6.1.1.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -42,7 +42,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>5.6.5</elasticsearch.version>
+        <elasticsearch.version>6.1.1</elasticsearch.version>
         <junit.version>4.12</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
             <organization>Automattic</organization>
             <organizationUrl>https://automattic.com/</organizationUrl>
         </developer>
+        <developer>
+            <name>Loren Siebert</name>
+            <email>loren@siebert.org</email>
+        </developer>
     </developers>
 
     <properties>

--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdReporterIndexStats.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdReporterIndexStats.java
@@ -26,7 +26,6 @@ public abstract class StatsdReporterIndexStats extends StatsdReporter {
     protected void sendStoreStats(String name, StoreStats storeStats) {
         if (null == storeStats) return;
         this.sendGauge(name, "size_in_bytes", storeStats.sizeInBytes());
-        this.sendGauge(name, "throttle_time_in_millis", storeStats.getThrottleTime().millis());
     }
 
     protected void sendIndexingStats(String name, IndexingStats indexingStats) {
@@ -112,6 +111,7 @@ public abstract class StatsdReporterIndexStats extends StatsdReporter {
         this.sendGauge(name, "delete_total", indexingStatsStats.getDeleteCount());
         this.sendGauge(name, "delete_time_in_millis", indexingStatsStats.getDeleteTime().millis());
         this.sendGauge(name, "delete_current", indexingStatsStats.getDeleteCurrent());
+        this.sendGauge(name, "throttle_time_in_millis", indexingStatsStats.getThrottleTime().millis());
     }
 
     protected void sendSearchStatsStats(String name, SearchStats.Stats searchStatsStats) {
@@ -143,6 +143,6 @@ public abstract class StatsdReporterIndexStats extends StatsdReporter {
         this.sendGauge(name, "hit_count", requestCacheStats.getHitCount());
         this.sendGauge(name, "miss_count", requestCacheStats.getMissCount());
         this.sendGauge(name, "evictions", requestCacheStats.getEvictions());
-        this.sendGauge(name, "memeory_size_in_bytes", requestCacheStats.getMemorySizeInBytes());
+        this.sendGauge(name, "memory_size_in_bytes", requestCacheStats.getMemorySizeInBytes());
     }
 }

--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
@@ -120,6 +120,7 @@ public class StatsdService extends AbstractLifecycleComponent {
                         state = StatsdService.this.clusterService.state();
                     } catch (AssertionError e) {
                         logger.info("Cluster state not set yet. Looping...");
+                        Thread.sleep(10);
                         continue;
                     }
                     boolean isClusterStarted = StatsdService.this.clusterService

--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
@@ -115,7 +115,13 @@ public class StatsdService extends AbstractLifecycleComponent {
         public void run() {
             try {
                 while (!StatsdService.this.closed.get()) {
-                    ClusterState state = StatsdService.this.clusterService.state();
+                    ClusterState state;
+                    try {
+                        state = StatsdService.this.clusterService.state();
+                    } catch (AssertionError e) {
+                        logger.info("Cluster state not set yet. Looping...");
+                        continue;
+                    }
                     boolean isClusterStarted = StatsdService.this.clusterService
                             .lifecycleState()
                             .equals(Lifecycle.State.STARTED);
@@ -145,7 +151,8 @@ public class StatsdService extends AbstractLifecycleComponent {
                                                 true,                               // circuitBreaker
                                                 false,                              // script,
                                                 false,                              // discoveryStats
-                                                false                               // ingest
+                                                false,                              // ingest
+                                                false                               // adaptiveSelection
                                         ),
                                         statsdNodeName,
                                         StatsdService.this.statsdReportFsDetails

--- a/src/plugin-metadata/plugin-security.policy
+++ b/src/plugin-metadata/plugin-security.policy
@@ -1,3 +1,3 @@
 grant {
-  permission java.net.SocketPermission "localhost:1024-", "listen, resolve";
+  permission java.net.SocketPermission "localhost:1024-", "listen, resolve, connect, accept";
 };

--- a/src/test/java/com/automattic/elasticsearch/statsd/test/StatsdPluginIntegrationTest.java
+++ b/src/test/java/com/automattic/elasticsearch/statsd/test/StatsdPluginIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
-@ESIntegTestCase.ClusterScope(maxNumDataNodes = 3, minNumDataNodes = 3, numClientNodes = 0, numDataNodes = 3, transportClientRatio = -1, randomDynamicTemplates = false)
+@ESIntegTestCase.ClusterScope(maxNumDataNodes = 3, minNumDataNodes = 3, numClientNodes = 0, numDataNodes = 3, transportClientRatio = -1)
 public class StatsdPluginIntegrationTest extends ESIntegTestCase {
 
     public static final int STATSD_SERVER_PORT = 12345;

--- a/src/test/resources/plugin-security-test.policy
+++ b/src/test/resources/plugin-security-test.policy
@@ -1,0 +1,5 @@
+grant {
+  permission java.net.SocketPermission "localhost:1024-", "listen,resolve,connect,accept";
+  permission javax.management.MBeanServerPermission "createMBeanServer";
+  permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+};

--- a/src/test/resources/plugin-security-test.policy
+++ b/src/test/resources/plugin-security-test.policy
@@ -2,4 +2,5 @@ grant {
   permission java.net.SocketPermission "localhost:1024-", "listen,resolve,connect,accept";
   permission javax.management.MBeanServerPermission "createMBeanServer";
   permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
 };


### PR DESCRIPTION
- Moved `throttle_time_in_millis` to indexing stats
- Spin wait for cluster state to be ready and available before
performing tests
- Add `adaptiveSelection` param to `nodeService.stats()` call
- Removed unknown `randomDynamicTemplates` param from
`@ESIntegTestCase.ClusterScope`
- Added security policy to be run during tests so we don't have to run
with security disabled.
- Updated README with separate instructions for 5.x and 6.x