### PR TITLE
Allow required socket operations to external statsd hosts.

### DIFF
--- a/src/plugin-metadata/plugin-security.policy
+++ b/src/plugin-metadata/plugin-security.policy
@@ -1,3 +1,4 @@
 grant {
-  permission java.net.SocketPermission "localhost:1024-", "listen, resolve, connect, accept";
+  permission java.net.SocketPermission "localhost:1024-", "accept,connect,listen,resolve";
+  permission java.net.SocketPermission "*:1024-", "accept,connect,resolve";
 };

--- a/src/test/resources/plugin-security-test.policy
+++ b/src/test/resources/plugin-security-test.policy
@@ -1,5 +1,6 @@
 grant {
-  permission java.net.SocketPermission "localhost:1024-", "listen,resolve,connect,accept";
+  permission java.net.SocketPermission "localhost:1024-", "accept,connect,listen,resolve";
+  permission java.net.SocketPermission "*:1024-", "accept,connect,resolve";
   permission javax.management.MBeanServerPermission "createMBeanServer";
   permission javax.management.MBeanPermission "-#-[-]", "queryNames";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";


### PR DESCRIPTION
Even though the plugin tests pass and it builds successfully, when installing it on an ES6 cluster with an external statsd host it complains about not being able to perform a few socket operations.

Instead of adding a wildcard policy this PR only adds what appears to be the minimum necessary to get it working.

Before:

```
Installing plugin: file:///var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0003/executors/master__a0811b7c-94ae-432f-8fa6-f7c6b761badf/runs/cb487939-d4e2-4021-bd45-ad0abf3be96d/containers/893cef0a-af91-4b89-bdeb-838d2acf14ee/elasticsearch-statsd-6.1.1.0.zip
-> Downloading file:///var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0003/executors/master__a0811b7c-94ae-432f-8fa6-f7c6b761badf/runs/cb487939-d4e2-4021-bd45-ad0abf3be96d/containers/893cef0a-af91-4b89-bdeb-838d2acf14ee/elasticsearch-statsd-6.1.1.0.zip
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@     WARNING: plugin requires additional permissions     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
* java.net.SocketPermission localhost:1024- connect,listen,accept,resolve
See http://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html
for descriptions of what these permissions allow and the associated risks.
-> Installed statsd
Setting Elasticsearch keystore bootstrap password
Make sure to update your password if you haven't already.
[2018-01-16T10:55:52,780][INFO ][o.e.n.Node               ] [master-0-node] initializing ...
[2018-01-16T10:55:53,849][INFO ][o.e.e.NodeEnvironment    ] [master-0-node] using [1] data paths, mounts [[/ (/dev/xvda9)]], net usable_space [124.4gb], net total_space [143gb], types [ext4]
[2018-01-16T10:55:53,850][INFO ][o.e.e.NodeEnvironment    ] [master-0-node] heap size [990.7mb], compressed ordinary object pointers [true]
[2018-01-16T10:55:53,852][INFO ][o.e.n.Node               ] [master-0-node] node name [master-0-node], node ID [8RhH0zrLTaq_b748HBcB0A]
[2018-01-16T10:55:53,852][INFO ][o.e.n.Node               ] [master-0-node] version[6.1.1], pid[3], build[bd92e7f/2017-12-17T20:23:25.338Z], OS[Linux/4.7.3-coreos-r3/amd64], JVM[Oracle Corporation/Java HotSpot(TM) 64-Bit Server VM/1.8.0_152/25.152-b16]
[2018-01-16T10:55:53,852][INFO ][o.e.n.Node               ] [master-0-node] JVM arguments [-Xms1g, -Xmx1g, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -XX:+HeapDumpOnOutOfMemoryError, -Xms1024M, -Xmx1024M, -Des.path.home=/var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0003/executors/master__a0811b7c-94ae-432f-8fa6-f7c6b761badf/runs/cb487939-d4e2-4021-bd45-ad0abf3be96d/containers/893cef0a-af91-4b89-bdeb-838d2acf14ee/elasticsearch-6.1.1, -Des.path.conf=/var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0003/executors/master__a0811b7c-94ae-432f-8fa6-f7c6b761badf/runs/cb487939-d4e2-4021-bd45-ad0abf3be96d/containers/893cef0a-af91-4b89-bdeb-838d2acf14ee/elasticsearch-6.1.1/config]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [aggs-matrix-stats]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [analysis-common]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [ingest-common]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-expression]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-mustache]
[2018-01-16T10:56:01,089][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-painless]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [mapper-extras]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [parent-join]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [percolator]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [reindex]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [repository-url]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [transport-netty4]
[2018-01-16T10:56:01,090][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [tribe]
[2018-01-16T10:56:01,091][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded plugin [statsd]
[2018-01-16T10:56:01,091][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded plugin [x-pack]
[2018-01-16T10:56:10,690][DEBUG][o.e.a.ActionModule       ] Using REST wrapper from plugin org.elasticsearch.xpack.XPackPlugin
[2018-01-16T10:56:11,473][INFO ][o.e.d.DiscoveryModule    ] [master-0-node] using discovery type [zen]
[2018-01-16T10:56:13,680][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [master-0-node] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: org.elasticsearch.common.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, com.timgroup.statsd.StatsDClientException: Failed to start StatsD client
  at com.automattic.elasticsearch.statsd.StatsdService.<init>(Unknown Source)
  while locating com.automattic.elasticsearch.statsd.StatsdService

1 error
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:125) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:112) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) ~[elasticsearch-cli-6.1.1.jar:6.1.1]
	at org.elasticsearch.cli.Command.main(Command.java:90) ~[elasticsearch-cli-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:85) ~[elasticsearch-6.1.1.jar:6.1.1]
Caused by: org.elasticsearch.common.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, com.timgroup.statsd.StatsDClientException: Failed to start StatsD client
  at com.automattic.elasticsearch.statsd.StatsdService.<init>(Unknown Source)
  while locating com.automattic.elasticsearch.statsd.StatsdService

1 error
	at org.elasticsearch.common.inject.InjectorImpl$4.get(InjectorImpl.java:771) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl.getInstance(InjectorImpl.java:801) ~[elasticsearch-6.1.1.jar:6.1.1]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_152]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_152]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_152]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_152]
	at org.elasticsearch.node.Node.<init>(Node.java:508) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.node.Node.<init>(Node.java:245) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:322) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:121) ~[elasticsearch-6.1.1.jar:6.1.1]
	... 6 more
Caused by: com.timgroup.statsd.StatsDClientException: Failed to start StatsD client
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:115) ~[?:?]
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:82) ~[?:?]
	at com.automattic.elasticsearch.statsd.StatsdService$1.run(StatsdService.java:75) ~[?:?]
	at com.automattic.elasticsearch.statsd.StatsdService$1.run(StatsdService.java:72) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_152]
	at com.automattic.elasticsearch.statsd.StatsdService.<init>(StatsdService.java:72) ~[?:?]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_152]
	at org.elasticsearch.common.inject.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:49) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:86) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:116) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl$4$1.call(InjectorImpl.java:762) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:818) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl$4.get(InjectorImpl.java:757) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl.getInstance(InjectorImpl.java:801) ~[elasticsearch-6.1.1.jar:6.1.1]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_152]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_152]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_152]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_152]
	at org.elasticsearch.node.Node.<init>(Node.java:508) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.node.Node.<init>(Node.java:245) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:322) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:121) ~[elasticsearch-6.1.1.jar:6.1.1]
	... 6 more
Caused by: java.security.AccessControlException: access denied ("java.net.SocketPermission" "198.51.100.1:49552" "connect,resolve")
	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:1.8.0_152]
	at java.security.AccessController.checkPermission(AccessController.java:884) ~[?:1.8.0_152]
	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549) ~[?:1.8.0_152]
	at java.lang.SecurityManager.checkConnect(SecurityManager.java:1051) ~[?:1.8.0_152]
	at java.net.DatagramSocket.connectInternal(DatagramSocket.java:138) ~[?:1.8.0_152]
	at java.net.DatagramSocket.connect(DatagramSocket.java:494) ~[?:1.8.0_152]
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:113) ~[?:?]
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:82) ~[?:?]
	at com.automattic.elasticsearch.statsd.StatsdService$1.run(StatsdService.java:75) ~[?:?]
	at com.automattic.elasticsearch.statsd.StatsdService$1.run(StatsdService.java:72) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_152]
	at com.automattic.elasticsearch.statsd.StatsdService.<init>(StatsdService.java:72) ~[?:?]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_152]
	at org.elasticsearch.common.inject.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:49) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:86) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:116) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl$4$1.call(InjectorImpl.java:762) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:818) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl$4.get(InjectorImpl.java:757) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.common.inject.InjectorImpl.getInstance(InjectorImpl.java:801) ~[elasticsearch-6.1.1.jar:6.1.1]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_152]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_152]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_152]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_152]
	at org.elasticsearch.node.Node.<init>(Node.java:508) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.node.Node.<init>(Node.java:245) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:212) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:322) ~[elasticsearch-6.1.1.jar:6.1.1]
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:121) ~[elasticsearch-6.1.1.jar:6.1.1]
	... 6 more
```

After:

```
Installing plugin: file:///var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0005/executors/master__c5eaca34-87a4-40dd-86b3-9920d3225e61/runs/6c04aa21-4aa0-4c0c-80a6-e7a96068a7d6/containers/2c974f9c-70d1-4afc-87b5-fb2d0ae26c91/elasticsearch-statsd-6.1.1.0.zip
-> Downloading file:///var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0005/executors/master__c5eaca34-87a4-40dd-86b3-9920d3225e61/runs/6c04aa21-4aa0-4c0c-80a6-e7a96068a7d6/containers/2c974f9c-70d1-4afc-87b5-fb2d0ae26c91/elasticsearch-statsd-6.1.1.0.zip

[===========>                                     ] 25%?? 
[========================>                        ] 51%?? 
[=====================================>           ] 77%?? 
[================================================>] 99%?? 
[=================================================] 100%?? 
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@     WARNING: plugin requires additional permissions     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
* java.net.SocketPermission *:1024- connect,accept,resolve
* java.net.SocketPermission localhost:1024- connect,listen,accept,resolve
See http://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html
for descriptions of what these permissions allow and the associated risks.
-> Installed statsd
Setting Elasticsearch keystore bootstrap password
Make sure to update your password if you haven't already.
[2018-01-16T11:27:01,970][INFO ][o.e.n.Node               ] [master-0-node] initializing ...
[2018-01-16T11:27:02,186][INFO ][o.e.e.NodeEnvironment    ] [master-0-node] using [1] data paths, mounts [[/ (/dev/xvda9)]], net usable_space [86.4gb], net total_space [143gb], types [ext4]
[2018-01-16T11:27:02,187][INFO ][o.e.e.NodeEnvironment    ] [master-0-node] heap size [990.7mb], compressed ordinary object pointers [true]
[2018-01-16T11:27:02,188][INFO ][o.e.n.Node               ] [master-0-node] node name [master-0-node], node ID [3NLnTrFVQdOKL5VVCneS-Q]
[2018-01-16T11:27:02,188][INFO ][o.e.n.Node               ] [master-0-node] version[6.1.1], pid[3], build[bd92e7f/2017-12-17T20:23:25.338Z], OS[Linux/4.7.3-coreos-r3/amd64], JVM[Oracle Corporation/Java HotSpot(TM) 64-Bit Server VM/1.8.0_152/25.152-b16]
[2018-01-16T11:27:02,189][INFO ][o.e.n.Node               ] [master-0-node] JVM arguments [-Xms1g, -Xmx1g, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -XX:+HeapDumpOnOutOfMemoryError, -Xms1024M, -Xmx1024M, -Des.path.home=/var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0005/executors/master__c5eaca34-87a4-40dd-86b3-9920d3225e61/runs/6c04aa21-4aa0-4c0c-80a6-e7a96068a7d6/containers/2c974f9c-70d1-4afc-87b5-fb2d0ae26c91/elasticsearch-6.1.1, -Des.path.conf=/var/lib/mesos/slave/slaves/6999412a-8911-4ee0-bdeb-22eadbcfea5b-S1/frameworks/6999412a-8911-4ee0-bdeb-22eadbcfea5b-0005/executors/master__c5eaca34-87a4-40dd-86b3-9920d3225e61/runs/6c04aa21-4aa0-4c0c-80a6-e7a96068a7d6/containers/2c974f9c-70d1-4afc-87b5-fb2d0ae26c91/elasticsearch-6.1.1/config]
[2018-01-16T11:27:08,389][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [aggs-matrix-stats]
[2018-01-16T11:27:08,389][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [analysis-common]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [ingest-common]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-expression]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-mustache]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [lang-painless]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [mapper-extras]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [parent-join]
[2018-01-16T11:27:08,390][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [percolator]
[2018-01-16T11:27:08,391][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [reindex]
[2018-01-16T11:27:08,391][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [repository-url]
[2018-01-16T11:27:08,391][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [transport-netty4]
[2018-01-16T11:27:08,391][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded module [tribe]
[2018-01-16T11:27:08,392][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded plugin [statsd]
[2018-01-16T11:27:08,392][INFO ][o.e.p.PluginsService     ] [master-0-node] loaded plugin [x-pack]
[2018-01-16T11:27:17,911][DEBUG][o.e.a.ActionModule       ] Using REST wrapper from plugin org.elasticsearch.xpack.XPackPlugin
[2018-01-16T11:27:18,667][INFO ][o.e.d.DiscoveryModule    ] [master-0-node] using discovery type [zen]
[2018-01-16T11:27:21,167][INFO ][o.e.n.Node               ] [master-0-node] initialized
[2018-01-16T11:27:21,167][INFO ][o.e.n.Node               ] [master-0-node] starting ...
[2018-01-16T11:27:21,177][INFO ][c.a.e.s.StatsdService    ] [master-0-node] StatsD reporting triggered every [1m] to host [198.51.100.1:44764] with metric prefix [elasticsearch.my-elasticsearch]
[2018-01-16T11:27:21,874][INFO ][o.e.t.TransportService   ] [master-0-node] publish_address {10.0.1.174:9300}, bound_addresses {[::1]:9300}, {127.0.0.1:9300}, {10.0.1.174:9300}
[2018-01-16T11:27:21,969][INFO ][o.e.b.BootstrapChecks    ] [master-0-node] bound or publishing to a non-loopback or non-link-local address, enforcing bootstrap checks
[2018-01-16T11:27:25,102][WARN ][o.e.d.z.ZenDiscovery     ] [master-0-node] not enough master nodes discovered during pinging (found [[Candidate{node={master-0-node}{3NLnTrFVQdOKL5VVCneS-Q}{kHG7MueuR3WYsjadtrRWQg}{master-0-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.1.174:9300}, clusterStateVersion=-1}]], but needed [2]), pinging again
[2018-01-16T11:27:30,193][INFO ][o.e.c.s.MasterService    ] [master-0-node] zen-disco-elected-as-master ([1] nodes joined)[{master-2-node}{a2t1wKyaT5S1tMw9_uhe1A}{zRLGa8JyTTmFdp-KOGdgdg}{master-2-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.3.58:9300}], reason: new_master {master-0-node}{3NLnTrFVQdOKL5VVCneS-Q}{kHG7MueuR3WYsjadtrRWQg}{master-0-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.1.174:9300}, added {{master-2-node}{a2t1wKyaT5S1tMw9_uhe1A}{zRLGa8JyTTmFdp-KOGdgdg}{master-2-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.3.58:9300},}
[2018-01-16T11:27:30,264][INFO ][o.e.c.s.ClusterApplierService] [master-0-node] new_master {master-0-node}{3NLnTrFVQdOKL5VVCneS-Q}{kHG7MueuR3WYsjadtrRWQg}{master-0-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.1.174:9300}, added {{master-2-node}{a2t1wKyaT5S1tMw9_uhe1A}{zRLGa8JyTTmFdp-KOGdgdg}{master-2-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.3.58:9300},}, reason: apply cluster state (from master [master {master-0-node}{3NLnTrFVQdOKL5VVCneS-Q}{kHG7MueuR3WYsjadtrRWQg}{master-0-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.1.174:9300} committed version [1] source [zen-disco-elected-as-master ([1] nodes joined)[{master-2-node}{a2t1wKyaT5S1tMw9_uhe1A}{zRLGa8JyTTmFdp-KOGdgdg}{master-2-node.my-elasticsearch.autoip.dcos.thisdcos.directory}{10.0.3.58:9300}]]])
[2018-01-16T11:27:30,285][INFO ][o.e.x.s.t.n.SecurityNetty4HttpServerTransport] [master-0-node] publish_address {10.0.1.174:1027}, bound_addresses {[::1]:1027}, {127.0.0.1:1027}, {10.0.1.174:1027}
[2018-01-16T11:27:30,286][INFO ][o.e.n.Node               ] [master-0-node] started
```
