### PR TITLE
honor collection time between collection steps

### DIFF
--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
@@ -117,6 +117,8 @@ public class StatsdService extends AbstractLifecycleComponent {
         public void run() {
             try {
                 while (!StatsdService.this.closed.get()) {
+                    long startTime = System.currentTimeMillis();
+
                     ClusterState state;
                     try {
                         state = StatsdService.this.clusterService.state();
@@ -207,8 +209,10 @@ public class StatsdService extends AbstractLifecycleComponent {
                         }
                     }
 
+                    long elapsedTime = System.currentTimeMillis() - startTime;
+
                     try {
-                        Thread.sleep(StatsdService.this.statsdRefreshInternal.millis());
+                        Thread.sleep(StatsdService.this.statsdRefreshInternal.millis() - elapsedTime);
                     } catch (InterruptedException e1) {
                         continue;
                     }


### PR DESCRIPTION
When collection time took too long(in our case on master node this collection took 1s) there may be shift in time intervals