### PR TITLE
ES 7.5.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.5.1          | 7.5.1.0        | Mar 19, 2020 |
 | 7.0.0          | 7.0.0.0        | Jan 7,  2019 |
 | 6.8.1          | 6.8.1.0        | Jun 26, 2019 |
 | 6.8.0          | 6.8.0.0        | Jun 26, 2019 |
@@ -97,12 +98,12 @@ The plugin artifacts are published to Maven Central and Github. To install a pre
 From Github:
 
 ```
-./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/7.0.0.0/elasticsearch-statsd-7.0.0.0.zip
+./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/7.5.1.0/elasticsearch-statsd-7.5.1.0.zip
 ```
 
 From Maven Central:
 ```
-./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.8.1.0/elasticsearch-statsd-6.8.1.0.zip
+./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/7.5.1.0/elasticsearch-statsd-7.5.1.0.zip
 ```
 
 Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
@@ -118,7 +119,7 @@ mvn clean package -Djava.security.policy=src/test/resources/plugin-security-test
 Once we have the artifact, install it with the following command:
 
 ```
-bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-7.0.0.0.zip
+bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-7.5.1.0.zip
 ```
 
 ## Installation Elasticsearch 5.x

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>7.0.0.0</version>
+    <version>7.5.1.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -46,7 +46,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>7.0.0</elasticsearch.version>
+        <elasticsearch.version>7.5.1</elasticsearch.version>
         <junit.version>4.12</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
@@ -171,7 +171,7 @@ public class StatsdService extends AbstractLifecycleComponent {
                                 try {
                                     StatsdReporter nodeIndicesStatsReporter = new StatsdReporterNodeIndicesStats(
                                             StatsdService.this.indicesService.stats(
-                                                    false // includePrevious
+                                                null // don't include previous stats
                                             ),
                                             statsdNodeName
                                     );


### PR DESCRIPTION
Adds compatibility for ES 7.5.1 via updating the call to `IndicesService::stats()`, whose signature has changed.