### PR TITLE
Update the plugin version to include trailing 0 (7.10.2.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>7.10.2</version>
+    <version>7.10.2.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>


### PR DESCRIPTION
The previous PR contained an error, the version was defined as `7.10.2` instead of the `7.10.2.0`, this PR addresses the issue.