### PR TITLE
Updated a few method signatures to be compatible with 7.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.16.2         | 7.16.2.0       | Dec 20, 2021 |
 | 7.10.2         | 7.10.2.0       | Apr 20, 2021 |
 | 7.9.3          | 7.9.3.0        | Oct 27, 2020 | 
 | 7.8.1          | 7.8.1.0        | Aug 10, 2020 |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>7.10.2.0</version>
+    <version>7.16.2.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -46,7 +46,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>7.10.2</elasticsearch.version>
+        <elasticsearch.version>7.16.2</elasticsearch.version>
         <junit.version>4.12</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.timgroup</groupId>
             <artifactId>java-statsd-client</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>
@@ -69,14 +69,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.7</version>
+            <version>2.17.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
+            <version>2.17.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/automattic/elasticsearch/plugin/StatsdPlugin.java
+++ b/src/main/java/com/automattic/elasticsearch/plugin/StatsdPlugin.java
@@ -3,7 +3,7 @@ package com.automattic.elasticsearch.plugin;
 import com.automattic.elasticsearch.statsd.StatsdService;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.ArrayList;

--- a/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
+++ b/src/main/java/com/automattic/elasticsearch/statsd/StatsdService.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.NodeService;
@@ -173,7 +173,7 @@ public class StatsdService extends AbstractLifecycleComponent {
                             }
 
                             // Maybe report index stats per node
-                            if (StatsdService.this.statsdReportNodeIndices && node.isDataNode()) {
+                            if (StatsdService.this.statsdReportNodeIndices && node.canContainData()) {
                                 try {
                                     StatsdReporter nodeIndicesStatsReporter = new StatsdReporterNodeIndicesStats(
                                             StatsdService.this.indicesService.stats(

--- a/src/test/java/com/automattic/elasticsearch/statsd/test/StatsdPluginIntegrationTest.java
+++ b/src/test/java/com/automattic/elasticsearch/statsd/test/StatsdPluginIntegrationTest.java
@@ -69,8 +69,8 @@ public class StatsdPluginIntegrationTest extends ESIntegTestCase {
     }
 
     @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings))
         .put("metrics.statsd.host", "localhost")
         .put("metrics.statsd.port", STATSD_SERVER_PORT)
         .put("metrics.statsd.prefix", "myhost"+nodeOrdinal)


### PR DESCRIPTION
As usual, there are a couple breaking, non-compatible method signature changes between minor versions of Elasticsearch. These changes address those. 

Build passed, but I did see this warning:
> [WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.elasticsearch:elasticsearch'

I think this was just because I didn't have a running cluster while testing. 